### PR TITLE
add a CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # pm-coding-template
+[![PM CI workflow](https://github.com/predictionmachine/pm-coding-template/actions/workflows/pm-gh-actions.yml/badge.svg)](https://github.com/predictionmachine/pm-coding-template/actions/workflows/pm-gh-actions.yml)
+
 Documents and Illustrates Coding Standards used at Prediction Machine
 
 As you ramp up on contributing code to Prediction Machine, 


### PR DESCRIPTION
## Description
Just a quick change to add the CI status badge to the README.md. In view workflow under Actions, there is an option there to generate a badge:
![image](https://user-images.githubusercontent.com/278558/119229753-3af38800-bace-11eb-81ed-a340c652e35d.png)
This is the one we're using