### PR TITLE
bring pm-gh-actions.yml to 0.3.3.1

### DIFF
--- a/.github/workflows/pm-gh-actions.yml
+++ b/.github/workflows/pm-gh-actions.yml
@@ -205,7 +205,6 @@ jobs:
     env:
       MIN_DOC_COV: 100
       COVERAGE_OUTPUT_PATH: output/coverage.xml
-      PYTEST_OUTPUT_PATH: output/pytest.xml
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -229,7 +228,7 @@ jobs:
           if [ requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
       - name: Test with pytest
         run: |
-          python -m pytest --continue-on-collection-errors --junit-xml $PYTEST_OUTPUT_PATH
+          python -m pytest --continue-on-collection-errors
       # HANDLE COVERAGE
       - name: Generate coverage report
         run: |
@@ -243,11 +242,6 @@ jobs:
           files: ${{ env.COVERAGE_OUTPUT_PATH }}
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional (default = false)
-      - name: Show unit test results
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        if: always()
-        with:
-          files: ${{ env.PYTEST_OUTPUT_PATH }}
       - name: Upload code coverage to codeclimate
         uses: paambaati/codeclimate-action@v2.7.5
         env:

--- a/.github/workflows/pm-gh-actions.yml
+++ b/.github/workflows/pm-gh-actions.yml
@@ -24,13 +24,12 @@ env:
   GUIDELINE_REPO: 'https://github.com/predictionmachine/pm-coding-template'
 
 jobs:
-
   # Check branch name standard as per `pm-coding-template`
   # Ref: https://github.com/predictionmachine/pm-coding-template#github-branches-pull-requests
   check-branch-naming-convention:
     runs-on: ubuntu-latest
     name: Check branch naming convention as per pm-coding-template
-    # if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' }}
     env:
       BRANCH_NAME_RULE: 'https://github.com/predictionmachine/pm-coding-template#github-branches-pull-requests'
     steps:

--- a/.github/workflows/pm-gh-actions.yml
+++ b/.github/workflows/pm-gh-actions.yml
@@ -30,7 +30,7 @@ jobs:
   check-branch-naming-convention:
     runs-on: ubuntu-latest
     name: Check branch naming convention as per pm-coding-template
-    if: ${{ github.event_name == 'pull_request' }}
+    # if: ${{ github.event_name == 'pull_request' }}
     env:
       BRANCH_NAME_RULE: 'https://github.com/predictionmachine/pm-coding-template#github-branches-pull-requests'
     steps:
@@ -49,13 +49,13 @@ jobs:
           header: invalid-branch-name-comments
           message: |
             👋 &nbsp; @${{ github.event.pull_request.user.login }}
-            Please use the valid branch name, [see here](${{ env.BRANCH_NAME_RULE }}).
-            Please make sure you have followed our [contributing guidelines](${{ env.GUIDELINE_REPO }}).
+            Please use a valid [branch name](${{ env.BRANCH_NAME_RULE }}).
+            Make sure you have followed our [contribution guidelines](${{ env.GUIDELINE_REPO }}).
       - name: Exit job for invalid branch name
         if: ${{ steps.branchCheck.outputs.is_valid_name == 'false' }}
         run: |
           echo "Invalid branch name: $GITHUB_HEAD_REF"
-          echo "Please use the standard mentioned here: ${{ env.BRANCH_NAME_RULE }}"
+          echo "Please use the standard mentioned here: $BRANCH_NAME_RULE"
           exit 1
 
   enforce-pr-description:

--- a/.github/workflows/pm-gh-actions.yml
+++ b/.github/workflows/pm-gh-actions.yml
@@ -2,7 +2,7 @@
 # Copyright (C) 2021 Prediction Machine Advisers, LLC
 # This file is available under MIT license
 # based on https://github.com/predictionmachine/pm-gh-actions/blob/main/.github/workflows/pm-gh-actions.yml
-# version 0.3.3
+# version 0.3.3.1
 ############################################################################################
 
 name: PM CI workflow

--- a/.github/workflows/pm-gh-actions.yml
+++ b/.github/workflows/pm-gh-actions.yml
@@ -29,7 +29,7 @@ jobs:
   # Ref: https://github.com/predictionmachine/pm-coding-template#github-branches-pull-requests
   check-branch-naming-convention:
     runs-on: ubuntu-latest
-    name: Check branch naming convention as per `pm-coding-template`
+    name: Check branch naming convention as per pm-coding-template
     if: ${{ github.event_name == 'pull_request' }}
     env:
       BRANCH_NAME_RULE: 'https://github.com/predictionmachine/pm-coding-template#github-branches-pull-requests'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
+# pm-version 0.1.1
 [tool.black]
-# your black config goes here
 # see https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-format
+# your black config goes here
 
 [tool.coverage.run]
-# your coverage config goes here
 # see https://coverage.readthedocs.io/en/latest/config.html
+omit = ["tests/*"]
 
 [tool.interrogate]
 # see https://interrogate.readthedocs.io/en/latest/#configuration

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
+# pm-version 0.1.1
 [flake8]
 # see https://flake8.pycqa.org/en/latest/user/options.html#options-list
 exclude =


### PR DESCRIPTION
the version was set to 0.3.3, but was behind true 0.3.3. This small fix brings it up to date, bringing in removal of extra test coverage reporting (and relying on codecov instead)