### PR TITLE
add `codeclimate.yml`

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,45 @@
+############################################################################################
+# Copyright (C) 2021 Prediction Machine Advisers, LLC
+# This file is available under MIT license
+# based on https://github.com/predictionmachine/pm-gh-actions/blob/main/.codelclimate.yml
+# pm-version 0.1.1
+############################################################################################
+# see https://docs.codeclimate.com/docs/advanced-configuration
+version: "2"         # required to adjust maintainability checks
+checks:
+#  argument-count:
+#    config:
+#      threshold: 4
+#  complex-logic:
+#    config:
+#      threshold: 4
+  file-lines:
+    config:
+      threshold: 400  # default is 250
+#  method-complexity:
+#    config:
+#      threshold: 5
+#  method-count:
+#    config:
+#      threshold: 20
+#  method-lines:
+#    config:
+#      threshold: 25
+#  nested-control-flow:
+#    config:
+#      threshold: 4
+#  return-statements:
+#    config:
+#      threshold: 4
+#  similar-code:
+#    config:
+#      threshold: # language-specific defaults. an override will affect all languages.
+#  identical-code:
+#    config:
+#      threshold: # language-specific defaults. an override will affect all languages.
+plugins:
+  sonar-python:
+    # see https://docs.codeclimate.com/docs/sonar-python
+    enabled: true
+    config:
+      minimum_severity: major  # default is "major"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,23 +2,23 @@
 # Copyright (C) 2021 Prediction Machine Advisers, LLC
 # This file is available under MIT license
 # based on https://github.com/predictionmachine/pm-gh-actions/blob/main/.codelclimate.yml
-# pm-version 0.1.1
+# pm-version 0.1.3-mod1
 ############################################################################################
 # see https://docs.codeclimate.com/docs/advanced-configuration
 version: "2"         # required to adjust maintainability checks
 checks:
-#  argument-count:
-#    config:
-#      threshold: 4
-#  complex-logic:
-#    config:
-#      threshold: 4
+  #  argument-count:
+  #    config:
+  #      threshold: 4
+  #  complex-logic:
+  #    config:
+  #      threshold: 4
   file-lines:
     config:
       threshold: 400  # default is 250
-#  method-complexity:
-#    config:
-#      threshold: 5
+  method-complexity:
+    config:
+      threshold: 6 # default is 5
 #  method-count:
 #    config:
 #      threshold: 20
@@ -38,6 +38,12 @@ checks:
 #    config:
 #      threshold: # language-specific defaults. an override will affect all languages.
 plugins:
+  # editorconfig:
+  #   # see https://docs.codeclimate.com/docs/editorconfig
+  #   enabled: true
+  shellcheck:
+    # see https://docs.codeclimate.com/docs/shellcheck
+    enabled: true
   sonar-python:
     # see https://docs.codeclimate.com/docs/sonar-python
     enabled: true


### PR DESCRIPTION
## Description
ClickUp [task](https://app.clickup.com/t/w5e0wj)

What functionality does this add/problem does this address?
we'd like coding template to configure codeclimate as well, which is
easiest to do by including a (versioned) .codeclimate.yml

This is a small change, only adding .codeclimate.yml and documenting its addition

## Checklist
- [x] Does the PR have an informative, carefully chosen **title**?
- [ ] Updated README.md and inline documentation as appropriate
- [x] New files have copyright statement at the top and a careful, useful description of what the file does
- [x] Have you followed the other [Coding standards](https://github.com/predictionmachine/pm-coding-template#code-contents)?
- [x] Applied *labels* to the PR

<!-- based on https://github.com/predictionmachine/pm-coding-template/blob/main/.github/pull_request_template.md -->
