### PR TITLE
add flake8 to pre-commit config and required mypy version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,5 @@
-# Copyright (C) 2021 Prediction Machine Advisers, LLC
-# This file is available under MIT license
-# based on https://github.com/predictionmachine/pm-github-actions/blob/main/.pre-commit-config.yaml
-# pm-version 0.1.1
-
 # Run `pre-commit install`
+# pm-version 0.1.2
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
@@ -24,6 +20,10 @@ repos:
     rev: 21.5b2
     hooks:
       - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
   - repo: https://github.com/dfm/black_nbconvert
     rev: 'v0.2.0'
     hooks:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,9 +2,11 @@ black~=21.5b2
 coverage[toml]~=5.5
 interrogate~=1.4.0
 flake8~=3.9.2
-mypy~=0.812
+mypy~=0.901
 pre-commit~=2.13.0
 pytest~=6.2.4
 pytest-cov~=2.12.1
 pytest-mock~=3.6.1
 pytest-xdist[psutil]~=2.2.1
+# use if you use requests
+# types-requests>=0.1.9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black~=21.5b2
+black~=21.5b2  # pycharm error on this is ok
 coverage[toml]~=5.5
 interrogate~=1.4.0
 flake8~=3.9.2


### PR DESCRIPTION
## Description
a bit of housekeeping -- bump dev requirements, add comments to `requirements-dev.txt` and make default pre-commit config run flake8 check

This is a small change.

## Checklist
- [x] Does the PR have an informative, carefully chosen **title**?
- [x] Have you followed the other [Coding standards](https://github.com/predictionmachine/pm-coding-template#code-contents)?
- [x] Applied *labels* to the PR

<!-- version 0.3.1 -->
<!-- based on https://github.com/predictionmachine/pm-coding-template/blob/main/.github/pull_request_template.md -->
