### PR TITLE
Feature: Add McCabe complexity option in flake8 config & update dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ black~=21.7b0  # pycharm error on this is ok
 coverage[toml]~=5.5
 flake8~=3.9.2
 interrogate~=1.4.0
+mccabe~=0.6.1  # check McCabe complexity. see https://github.com/PyCQA/mccabe
 isort~=5.9.3
 mypy==0.910
 pre-commit~=2.13.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,9 @@ exclude =
 ignore = E731,W503,E501
 count = True
 statistics = True
+# mccabe flake8 plugin, set the maximum allowed McCabe complexity value
+# see https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-max-complexity
+max-complexity = 7
 max-line-length = 120
 # flake8-copyright plugin, see https://github.com/savoirfairelinux/flake8-copyright
 copyright-check = True


### PR DESCRIPTION
## Description
DEV-1225

What functionality does this add/problem does this fix?
- Add McCabe code complexity option in flake8 config 
- Add `mccabe` to requirements-dev.txt

This is a 🐁 change.

## Checklist
- [x] Set an informative, carefully chosen **title**
- [x] Applied *labels* to the PR
- [ ] Updated README.md and inline documentation as appropriate
- [x] Followed [Coding standards](https://github.com/predictionmachine/pm-coding-template/blob/main/docs/coding-standard.md#coding-standard)
- [ ] Added TODO comments about the work not shipped in this PR
- [ ] Documented bugs/issues you had to work around

<!-- version 0.4.1 -->
<!-- based on https://github.com/predictionmachine/pm-coding-template/blob/main/.github/pull_request_template.md -->
