### PR TITLE
Remove mccabe dependency from dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ black~=21.7b0  # pycharm error on this is ok
 coverage[toml]~=5.5
 flake8~=3.9.2
 interrogate~=1.4.0
-mccabe~=0.6.1  # check McCabe complexity. see https://github.com/PyCQA/mccabe
 isort~=5.9.3
 mypy==0.910
 pre-commit~=2.13.0


### PR DESCRIPTION
## Description
DEV-1228

What functionality does this add/problem does this fix?
- We don't need explicitly listing mccabe in requirements-dev.txt, since flake8 pulls in the right version of it as a dependency by default.

This is a 🐁  change.

## Checklist
- [x] Set an informative, carefully chosen **title**
- [x] Applied *labels* to the PR
- [ ] Updated README.md and inline documentation as appropriate
- [x] Followed [Coding standards](https://github.com/predictionmachine/pm-coding-template/blob/main/docs/coding-standard.md#coding-standard)
- [ ] Added TODO comments about the work not shipped in this PR
- [ ] Documented bugs/issues you had to work around

<!-- version 0.4.1 -->
<!-- based on https://github.com/predictionmachine/pm-coding-template/blob/main/.github/pull_request_template.md -->
